### PR TITLE
Adding zipped file with raw NPI data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 t_measure_data_years.sas7bdat filter=lfs diff=lfs merge=lfs -text
 ahrf2024_feb2025.sas7bdat filter=lfs diff=lfs merge=lfs -text
+npidata_pfile_20050523-20250608.zip filter=lfs diff=lfs merge=lfs -text

--- a/raw_data/NPI/npidata_pfile_20050523-20250608.zip
+++ b/raw_data/NPI/npidata_pfile_20050523-20250608.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1c73c3506fdb7f721bdc6f49c3327563346b93cf1deb16a1c4f766a0f394070
+size 971208699


### PR DESCRIPTION
The zipped npidata_pfile has the raw NPI dataset downloaded on June 16th, 2025, with data as of June 8th, 2025. Used for the calculation of v062 (Mental health providers) and v131 (Other PCPs).